### PR TITLE
Add end of track MIDI event to recordings

### DIFF
--- a/src/apps/recorder/index.js
+++ b/src/apps/recorder/index.js
@@ -67,7 +67,11 @@ export default function () {
               console.warn('currently support only note-on and note-off')
               return null
           }
-        }).filter(x => x !== null)
+        }).filter(x => x !== null).concat({
+          deltaTime: 0,
+          meta: true,
+          type: 'endOfTrack',
+        })
       ]
     })
     const name = `${formatDate(startTime)}_${formatDate(new Date())}_${eventHistory.length}.mid`


### PR DESCRIPTION
First commit :) 

I noticed when I loaded up the Recorded MIDI files from the Recorder into MuseScore, there was an error. After some quick investigation -- noticed that this was because the "End of Track" event was missing -- so I added it.

## Before
<img width="473" alt="Screen Shot 2020-12-27 at 3 25 09 AM" src="https://user-images.githubusercontent.com/6259534/103169715-2b0f9a80-47f3-11eb-9e28-7ba5492c0383.png">

## After
<img width="1452" alt="Screen Shot 2020-12-27 at 3 23 23 AM" src="https://user-images.githubusercontent.com/6259534/103169690-e257e180-47f2-11eb-8bfc-29cbc8b886e4.png">

